### PR TITLE
Add support for scoped tokens and client_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,24 @@ A plugin to get a jwt or installation token for a github app.
 
 The following settings changes this plugin's behavior.
 
-* APP_ID (required) github app id.
+## Authentication Parameters
+* APP_ID (optional) github app id (legacy, use CLIENT_ID instead).
+* CLIENT_ID (optional, recommended) github app client id string.
 * PEM (optional) rsa private key.
 * PEM_FILE (optional) local file path of rsa private key.
-* PEM_B64 (optional) local file path of base64 encoded rsa private key.
+* PEM_B64 (optional) base64 encoded rsa private key.
+
+## Installation & Repository Scoping
 * INSTALLATION (optional) installation id. required if wanting a token.
+* REPO_IDS (optional) comma-separated list of repository IDs to scope token to.
+* REPO_NAMES (optional) comma-separated list of repository names to scope token to.
+* REPO_IDS_FILE (optional) file containing repository IDs (newline or comma separated).
+* PERMISSIONS (optional) comma-separated permissions in format "resource:permission" (e.g., "contents:read,issues:write").
+
+## Output Options
 * JWT_FILE (optional) output file for jwt.
 * TOKEN_FILE (optional) output file for token.
-* JSON_FILE (optional) output file for both jwt and token in json.
+* JSON_FILE (optional) output file for both jwt and token with metadata.
 * JWT_SECRET (optional) harness secret id for setting jwt as a secret
 * TOKEN_SECRET (optional) harness secret id for setting token as a secret
 * JSON_SECRET (optional) harness secret id for setting json as a secret
@@ -26,9 +36,34 @@ If setting harness secrets, you also need to set the follow in the environment f
 - HARNESS_PLATFORM_ORGANIZATION: organization id
 - HARNESS_PLATFORM_PROJECT: project id
 
-**one of PEM, PEM_FILE, PEM_B64 is required**
+## Requirements
 
-Below is an example `.drone.yml` that uses this plugin.
+**Authentication**: Either `APP_ID` or `CLIENT_ID` is required (prefer `CLIENT_ID`).
+**Private Key**: One of `PEM`, `PEM_FILE`, or `PEM_B64` is required.
+**Repository Scoping**: Only one of `REPO_IDS`, `REPO_NAMES`, or `REPO_IDS_FILE` can be used to limit repo access.
+**Permission Scoping**: `PERMISSIONS` can be used to scope down token permissions.
+**Installation Token**: `INSTALLATION` is required when requesting tokens.
+
+## Examples
+
+### Basic JWT Generation
+
+```yaml
+kind: pipeline
+name: default
+
+steps:
+- name: generate github app jwt
+  image: rssnyder/drone-github-app
+  pull: if-not-exists
+  settings:
+    CLIENT_ID: "Iv1.a629723bfa6c7c08"
+    PEM_B64:
+      from_secret: github_app_b64
+    JWT_FILE: app.jwt
+```
+
+### Installation Token with Repository Scoping
 
 ```yaml
 kind: pipeline
@@ -39,14 +74,35 @@ steps:
   image: rssnyder/drone-github-app
   pull: if-not-exists
   settings:
-    APP_ID: "264043"
+    CLIENT_ID: "Iv1.a629723bfa6c7c08"
     INSTALLATION: "31437931"
+    REPO_IDS: "1001,1002,1003"
+    PERMISSIONS: "contents:read,issues:write,pull_requests:read"
     PEM_B64:
       from_secret: github_app_b64
     JSON_FILE: output.json
 ```
 
-Below is an example harness step that uses this plugin.
+### Repository Names with Custom Permissions
+
+```yaml
+kind: pipeline
+name: default
+
+steps:
+- name: get token for specific repos
+  image: rssnyder/drone-github-app
+  pull: if-not-exists
+  settings:
+    CLIENT_ID: "Iv1.a629723bfa6c7c08"
+    INSTALLATION: "31437931"
+    REPO_NAMES: "hello-world,my-awesome-repo"
+    PERMISSIONS: "contents:write,actions:read"
+    PEM_FILE: /secrets/github-app.pem
+    TOKEN_FILE: github_token.txt
+```
+
+### Harness CI Example
 
 ```yaml
 - step:
@@ -54,13 +110,84 @@ Below is an example harness step that uses this plugin.
     name: get token
     identifier: get_token
     spec:
-    connectorRef: dockerhub
-    image: rssnyder/drone-github-app
-    settings:
-        APP_ID: "264043"
+      connectorRef: dockerhub
+      image: rssnyder/drone-github-app
+      settings:
+        CLIENT_ID: "Iv1.a629723bfa6c7c08"
         INSTALLATION: "31437931"
+        REPO_IDS: "1001,1002"
+        PERMISSIONS: "contents:read,metadata:read"
         PEM_B64: <+secrets.getValue("github_app_b64")>
         JSON_FILE: output.json
+```
+
+### Using Repository IDs from File
+
+```yaml
+kind: pipeline
+name: default
+
+steps:
+- name: get token from repo file
+  image: rssnyder/drone-github-app
+  pull: if-not-exists
+  settings:
+    CLIENT_ID: "Iv1.a629723bfa6c7c08"
+    INSTALLATION: "31437931"
+    REPO_IDS_FILE: ./repo_list.txt
+    PERMISSIONS: "issues:write,pull_requests:write"
+    PEM_B64:
+      from_secret: github_app_b64
+    TOKEN_SECRET: github_installation_token
+```
+
+## JSON Output Format
+
+When using `JSON_FILE` or `JSON_SECRET`, the output includes token information:
+
+```json
+{
+  "token": {
+    "token": "ghs_12345ABCDE98765",
+    "expires_at": "2016-07-11T22:14:10Z",
+    "permissions": {
+      "contents": "read",
+      "issues": "write"
+    },
+    "repository_selection": "selected",
+    "repositories": [
+      {
+        "id": 1296269,
+        "name": "Hello-World"
+      }
+    ]
+  },
+  "jwt": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "repository_count": 1,
+  "permissions": {
+    "contents": "read",
+    "issues": "write"
+  }
+}
+```
+
+## Repository ID File Format
+
+When using `REPO_IDS_FILE`, the file can contain repository IDs in various formats:
+
+```text
+# One per line
+1001
+1002
+1003
+
+# Comma-separated on same line
+1004,1005,1006
+
+# Mixed format
+1007
+1008,1009
+1010
 ```
 
 # Building
@@ -94,7 +221,7 @@ docker run --rm -e PLUGIN_PARAM1=foo -e PLUGIN_PARAM2=bar \
 
 ## Installations
 
-If you need to view the intallations for your app, use the plugin to get a JWT and make the following HTTP call:
+If you need to view the installations for your app, use the plugin to get a JWT and make the following HTTP call:
 
 ```shell
 curl \

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -211,9 +211,7 @@ func Exec(ctx context.Context, args Args) (err error) {
 	if args.JsonFile != "" {
 		jsonData := JsonOutput{
 			Token:           tokenData,
-			Jwt:             jwtSigned,
-			RepositoryCount: len(tokenData.Repositories),
-			Permissions:     tokenData.Permissions,
+			Jwt:             jwtSigned
 		}
 		file, err := json.MarshalIndent(jsonData, "", " ")
 		if err != nil {
@@ -243,6 +241,8 @@ func Exec(ctx context.Context, args Args) (err error) {
 	}
 	if args.JsonSecret != "" {
 		jsonData := JsonOutput{
+			Token: tokenData,
+			Jwt:   jwtSigned
 		}
 		file, err := json.MarshalIndent(jsonData, "", " ")
 		if err != nil {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -77,8 +77,6 @@ type TokenResponseRepository struct {
 type JsonOutput struct {
 	Token           TokenResponse `json:"token"`
 	Jwt             string        `json:"jwt"`
-	RepositoryCount int           `json:"repository_count,omitempty"`
-	Permissions     map[string]string `json:"permissions,omitempty"`
 }
 
 // Exec executes the plugin.

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -243,10 +243,6 @@ func Exec(ctx context.Context, args Args) (err error) {
 	}
 	if args.JsonSecret != "" {
 		jsonData := JsonOutput{
-			Token:           tokenData,
-			Jwt:             jwtSigned,
-			RepositoryCount: len(tokenData.Repositories),
-			Permissions:     tokenData.Permissions,
 		}
 		file, err := json.MarshalIndent(jsonData, "", " ")
 		if err != nil {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -28,6 +30,7 @@ type Args struct {
 
 	// TODO replace or remove
 	AppId         string `envconfig:"PLUGIN_APP_ID"`
+	ClientId      string `envconfig:"PLUGIN_CLIENT_ID"` // Recommended alternative to APP_ID
 	Pem           string `envconfig:"PLUGIN_PEM"`
 	PemFile       string `envconfig:"PLUGIN_PEM_FILE"`
 	PemB64        string `envconfig:"PLUGIN_PEM_B64"`
@@ -39,6 +42,14 @@ type Args struct {
 	TokenSecret   string `envconfig:"PLUGIN_TOKEN_SECRET"`
 	JsonSecret    string `envconfig:"PLUGIN_JSON_SECRET"`
 	SecretManager string `envconfig:"PLUGIN_SECRET_MANAGER"`
+
+	// Repository selection (mutually exclusive)
+	RepoIDs     string `envconfig:"PLUGIN_REPO_IDS"`     // Comma-separated list of repository IDs
+	RepoNames   string `envconfig:"PLUGIN_REPO_NAMES"`   // Comma-separated list of repository names
+	RepoIDsFile string `envconfig:"PLUGIN_REPO_IDS_FILE"` // File containing repository IDs
+
+	// Permissions for installation token
+	Permissions string `envconfig:"PLUGIN_PERMISSIONS"` // Comma-separated list of permissions (e.g., "contents:read,issues:write")
 }
 
 // AppResponse is what github returns when querying yourself
@@ -49,21 +60,42 @@ type AppResponse struct {
 
 // TokenResponse is what github returns when gettting an installation token
 type TokenResponse struct {
-	Token     string `json:"token"`
-	ExpiresAt string `json:"expires_at"`
+	Token              string                    `json:"token"`
+	ExpiresAt          string                    `json:"expires_at"`
+	Permissions        map[string]string         `json:"permissions,omitempty"`
+	RepositorySelection string                   `json:"repository_selection,omitempty"`
+	Repositories       []TokenResponseRepository `json:"repositories,omitempty"`
+}
+
+// TokenResponseRepository represents a repository in the token response
+type TokenResponseRepository struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
 }
 
 // JsonOutput is custom output for json file
 type JsonOutput struct {
-	Token TokenResponse `json:"token"`
-	Jwt   string        `json:"jwt"`
+	Token           TokenResponse `json:"token"`
+	Jwt             string        `json:"jwt"`
+	RepositoryCount int           `json:"repository_count,omitempty"`
+	Permissions     map[string]string `json:"permissions,omitempty"`
 }
 
 // Exec executes the plugin.
 func Exec(ctx context.Context, args Args) (err error) {
 
-	if args.AppId == "" {
-		return errors.New("app id needs to be set")
+	if args.AppId == "" && args.ClientId == "" {
+		return errors.New("either app_id or client_id needs to be set")
+	}
+
+	if args.AppId != "" && args.ClientId != "" {
+		return errors.New("only one of app_id or client_id should be set, not both. Prefer client_id for future GHEC with Data Residency compatibility.")
+	}
+
+	// Validate repository selection parameters
+	err = validateRepositoryArgs(args)
+	if err != nil {
+		return err
 	}
 
 	var bPem []byte
@@ -92,10 +124,16 @@ func Exec(ctx context.Context, args Args) (err error) {
 		return err
 	}
 
+	// Determine the issuer - use ClientId if provided, otherwise AppId
+	issuer := args.AppId
+	if args.ClientId != "" {
+		issuer = args.ClientId
+	}
+
 	builtToken := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
 		"iat": time.Now().Unix(),
 		"exp": time.Now().Add(time.Minute * time.Duration(10)).Unix(),
-		"iss": args.AppId,
+		"iss": issuer,
 	})
 
 	jwtSigned, err := builtToken.SignedString(signKey)
@@ -112,12 +150,44 @@ func Exec(ctx context.Context, args Args) (err error) {
 
 	var tokenData TokenResponse
 	if args.Installation != "" {
-		tokenData, err = installationToken(jwtSigned, args.Installation)
+		// Parse repository data if any repository selection is specified
+		var repoData map[string]interface{}
+		if args.RepoIDs != "" || args.RepoNames != "" || args.RepoIDsFile != "" {
+			repoData, err = parseRepositoryData(args)
+			if err != nil {
+				return err
+			}
+		}
+		
+		// Parse permissions if provided
+		var permissions map[string]string
+		if args.Permissions != "" {
+			permissions, err = parsePermissions(args.Permissions)
+			if err != nil {
+				return err
+			}
+		}
+		
+		tokenData, err = installationToken(jwtSigned, args.Installation, repoData, permissions)
 		if err != nil {
 			return err
 		}
 
-		log.Println(fmt.Sprintf("token recived, expires %s", tokenData.ExpiresAt))
+		// Log token information including repository details
+		logMsg := fmt.Sprintf("token received, expires %s", tokenData.ExpiresAt)
+		if len(tokenData.Repositories) > 0 {
+			logMsg += fmt.Sprintf(", repositories: %d", len(tokenData.Repositories))
+			for _, repo := range tokenData.Repositories {
+				log.Println(fmt.Sprintf("  - %s (ID: %d)", repo.Name, repo.ID))
+			}
+		}
+		if len(tokenData.Permissions) > 0 {
+			logMsg += ", permissions:"
+			for resource, permission := range tokenData.Permissions {
+				logMsg += fmt.Sprintf(" %s:%s", resource, permission)
+			}
+		}
+		log.Println(logMsg)
 	}
 
 	if args.JwtFile != "" {
@@ -140,8 +210,10 @@ func Exec(ctx context.Context, args Args) (err error) {
 
 	if args.JsonFile != "" {
 		jsonData := JsonOutput{
-			Token: tokenData,
-			Jwt:   jwtSigned,
+			Token:           tokenData,
+			Jwt:             jwtSigned,
+			RepositoryCount: len(tokenData.Repositories),
+			Permissions:     tokenData.Permissions,
 		}
 		file, err := json.MarshalIndent(jsonData, "", " ")
 		if err != nil {
@@ -171,8 +243,10 @@ func Exec(ctx context.Context, args Args) (err error) {
 	}
 	if args.JsonSecret != "" {
 		jsonData := JsonOutput{
-			Token: tokenData,
-			Jwt:   jwtSigned,
+			Token:           tokenData,
+			Jwt:             jwtSigned,
+			RepositoryCount: len(tokenData.Repositories),
+			Permissions:     tokenData.Permissions,
 		}
 		file, err := json.MarshalIndent(jsonData, "", " ")
 		if err != nil {
@@ -186,4 +260,139 @@ func Exec(ctx context.Context, args Args) (err error) {
 		log.Println(fmt.Sprintf("json saved in %s", args.JsonSecret))
 	}
 	return
+}
+
+// validateRepositoryArgs validates that repository selection arguments are mutually exclusive
+// and that installation is required when repository selection is used
+func validateRepositoryArgs(args Args) error {
+	repoArgsCount := 0
+	if args.RepoIDs != "" {
+		repoArgsCount++
+	}
+	if args.RepoNames != "" {
+		repoArgsCount++
+	}
+	if args.RepoIDsFile != "" {
+		repoArgsCount++
+	}
+
+	if repoArgsCount > 1 {
+		return errors.New("only one of repo_ids, repo_names, or repo_ids_file can be specified")
+	}
+
+	if repoArgsCount > 0 && args.Installation == "" {
+		return errors.New("installation must be specified when using repository selection")
+	}
+
+	return nil
+}
+
+// parseRepositoryData parses repository data from the various input sources
+// Returns a map with either "repository_ids" ([]int) or "repositories" ([]string)
+func parseRepositoryData(args Args) (map[string]interface{}, error) {
+	var items []string
+	useNames := false
+
+	if args.RepoIDs != "" {
+		items = strings.Split(strings.TrimSpace(args.RepoIDs), ",")
+	} else if args.RepoNames != "" {
+		items = strings.Split(strings.TrimSpace(args.RepoNames), ",")
+		useNames = true
+	} else if args.RepoIDsFile != "" {
+		content, err := os.ReadFile(args.RepoIDsFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read repo_ids_file: %v", err)
+		}
+		// Split by newlines and commas, filter empty strings
+		lines := strings.Split(string(content), "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if line != "" {
+				if strings.Contains(line, ",") {
+					// Split comma-separated values on this line
+					lineItems := strings.Split(line, ",")
+					for _, item := range lineItems {
+						item = strings.TrimSpace(item)
+						if item != "" {
+							items = append(items, item)
+						}
+					}
+				} else {
+					items = append(items, line)
+				}
+			}
+		}
+	}
+
+	if len(items) == 0 {
+		return nil, nil
+	}
+
+	if len(items) > 500 {
+		return nil, errors.New("repository list cannot contain more than 500 entries")
+	}
+
+	if useNames {
+		// Return repository names as strings (repo name only, not owner/repo)
+		var repoNames []string
+		for _, name := range items {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				// Validate that this is just a repo name, not owner/repo format
+				if strings.Contains(name, "/") {
+					return nil, fmt.Errorf("repository name '%s' should not include owner - use just the repository name (e.g., 'hello-world' not 'owner/hello-world')", name)
+				}
+				repoNames = append(repoNames, name)
+			}
+		}
+		return map[string]interface{}{"repositories": repoNames}, nil
+	} else {
+		// Convert string IDs to integers
+		var repoIDs []int
+		for _, idStr := range items {
+			idStr = strings.TrimSpace(idStr)
+			if idStr == "" {
+				continue
+			}
+			id, err := strconv.Atoi(idStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid repository ID '%s': %v", idStr, err)
+			}
+			repoIDs = append(repoIDs, id)
+		}
+		return map[string]interface{}{"repository_ids": repoIDs}, nil
+	}
+}
+
+// parsePermissions parses permissions from comma-separated string in format "resource:permission"
+func parsePermissions(permissionsStr string) (map[string]string, error) {
+	if permissionsStr == "" {
+		return nil, nil
+	}
+
+	permissions := make(map[string]string)
+	items := strings.Split(strings.TrimSpace(permissionsStr), ",")
+
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+
+		parts := strings.Split(item, ":")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid permission format '%s': expected 'resource:permission'", item)
+		}
+
+		resource := strings.TrimSpace(parts[0])
+		permission := strings.TrimSpace(parts[1])
+
+		if resource == "" || permission == "" {
+			return nil, fmt.Errorf("invalid permission format '%s': resource and permission cannot be empty", item)
+		}
+
+		permissions[resource] = permission
+	}
+
+	return permissions, nil
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -208,8 +208,8 @@ func Exec(ctx context.Context, args Args) (err error) {
 
 	if args.JsonFile != "" {
 		jsonData := JsonOutput{
-			Token:           tokenData,
-			Jwt:             jwtSigned
+			Token: tokenData,
+			Jwt:   jwtSigned,
 		}
 		file, err := json.MarshalIndent(jsonData, "", " ")
 		if err != nil {
@@ -240,7 +240,7 @@ func Exec(ctx context.Context, args Args) (err error) {
 	if args.JsonSecret != "" {
 		jsonData := JsonOutput{
 			Token: tokenData,
-			Jwt:   jwtSigned
+			Jwt:   jwtSigned,
 		}
 		file, err := json.MarshalIndent(jsonData, "", " ")
 		if err != nil {

--- a/plugin/util.go
+++ b/plugin/util.go
@@ -5,6 +5,7 @@
 package plugin
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -63,14 +64,49 @@ func validateJWT(jwt string) (response AppResponse, err error) {
 }
 
 // installationToken returns a github pat for the given installation scope
-func installationToken(jwt, installation string) (response TokenResponse, err error) {
-	req, err := http.NewRequest("POST", fmt.Sprintf("https://api.github.com/app/installations/%s/access_tokens", installation), nil)
+// If repoData is provided, the token will be scoped to those repositories
+// If permissions is provided, the token will have those specific permissions
+func installationToken(jwt, installation string, repoData map[string]interface{}, permissions map[string]string) (response TokenResponse, err error) {
+	var reqBody *bytes.Buffer
+	
+	// Build request data with repositories and/or permissions if provided
+	// Expected JSON structure:
+	// {
+	//   "repositories": ["repo1", "repo2"] OR "repository_ids": [1001, 1002],
+	//   "permissions": {"contents": "read", "issues": "write"}
+	// }
+	reqData := make(map[string]interface{})
+	
+	if repoData != nil {
+		for key, value := range repoData {
+			reqData[key] = value
+		}
+	}
+	
+	if permissions != nil && len(permissions) > 0 {
+		reqData["permissions"] = permissions
+	}
+	
+	if len(reqData) > 0 {
+		jsonData, err := json.Marshal(reqData)
+		if err != nil {
+			return response, err
+		}
+		reqBody = bytes.NewBuffer(jsonData)
+	} else {
+		reqBody = bytes.NewBuffer([]byte{})
+	}
+	
+	req, err := http.NewRequest("POST", fmt.Sprintf("https://api.github.com/app/installations/%s/access_tokens", installation), reqBody)
 	if err != nil {
 		return
 	}
 
 	req.Header.Add("Accept", "application/vnd.github+json")
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwt))
+	if len(reqData) > 0 {
+		req.Header.Add("Content-Type", "application/json")
+	}
 
 	client := &http.Client{}
 	resp, err := client.Do(req)


### PR DESCRIPTION
This allows the plugin to be called for a subset of the repos and permissions that the installation has access to. Ideally this will allow Harness to pass in a list (file or flat) of repos for a project and get a token that's appropriately scoped. 

I'm not a Go coder though, and some of this feels like it is not idiomatic go. 

There's a few additional inclusions here: 
1. Supporting client ID, not just app ID, in the JWT. This is needed for supporting an app registration that is synced across Github.com and GHEC with data residency.
2. Save the list of repos and permissions that the resulting token has access to. Unsure if it's very useful, but could be. Seems a shame to throw it away. 

The list of repos is expected to be passed in as a comma delineated list of either repo IDs or repo names, or a file containing a comma or newline delineated list of repository IDs. 

The app can only get a scoped token for repos and permissions it already has within an org - it cannot go cross org or request permissions/repos it doesn't have access to. The limit is 500 repos. https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app

Openly - I have not tested this yet as I don't have a Harness setup. 